### PR TITLE
Make Lens.key and friends work on Keywords / Access

### DIFF
--- a/lib/lens.ex
+++ b/lib/lens.ex
@@ -27,16 +27,16 @@ defmodule Lens do
 
   deflens key(key) do
     fn data, fun ->
-      {res, updated} = fun.(Map.get(data, key))
-      {[res], Map.put(data, key, updated)}
+      {res, updated} = fun.(access_get(data, key))
+      {[res], access_put(data, key, updated)}
     end
   end
 
   deflens keys(keys) do
     fn data, fun ->
       {res, changed} = Enum.reduce(keys, {[], data}, fn key, {results, data} ->
-        {res, changed} = fun.(Map.get(data, key))
-        {[res | results], Map.put(data, key, changed)}
+        {res, changed} = fun.(access_get(data, key))
+        {[res | results], access_put(data, key, changed)}
       end)
 
       {Enum.reverse(res), changed}
@@ -121,4 +121,15 @@ defmodule Lens do
 
     {Enum.concat(res), changed}
   end
+
+  defp access_get(data, key) when is_map(data), do: Map.get(data, key)
+  defp access_get(data, key), do: Access.get(data, key)
+
+  defp access_put(data, key, value) when is_map(data), do: Map.put(data, key, value)
+  defp access_put(data, key, value) do
+    {_, updated} = Access.get_and_update(data, key, fn _ -> {nil, value} end)
+    updated
+  end
+
 end
+

--- a/lib/lens.ex
+++ b/lib/lens.ex
@@ -27,16 +27,16 @@ defmodule Lens do
 
   deflens key(key) do
     fn data, fun ->
-      {res, updated} = fun.(data_get_key(data, key))
-      {[res], data_set_key(data, key, updated)}
+      {res, updated} = fun.(get_at_key(data, key))
+      {[res], set_at_key(data, key, updated)}
     end
   end
 
   deflens keys(keys) do
     fn data, fun ->
       {res, changed} = Enum.reduce(keys, {[], data}, fn key, {results, data} ->
-        {res, changed} = fun.(data_get_key(data, key))
-        {[res | results], data_set_key(data, key, changed)}
+        {res, changed} = fun.(get_at_key(data, key))
+        {[res | results], set_at_key(data, key, changed)}
       end)
 
       {Enum.reverse(res), changed}
@@ -122,11 +122,11 @@ defmodule Lens do
     {Enum.concat(res), changed}
   end
 
-  defp data_get_key(data, key) when is_map(data), do: Map.get(data, key)
-  defp data_get_key(data, key), do: Access.get(data, key)
+  defp get_at_key(data, key) when is_map(data), do: Map.get(data, key)
+  defp get_at_key(data, key), do: Access.get(data, key)
 
-  defp data_set_key(data, key, value) when is_map(data), do: Map.put(data, key, value)
-  defp data_set_key(data, key, value) do
+  defp set_at_key(data, key, value) when is_map(data), do: Map.put(data, key, value)
+  defp set_at_key(data, key, value) do
     {_, updated} = Access.get_and_update(data, key, fn _ -> {nil, value} end)
     updated
   end

--- a/lib/lens.ex
+++ b/lib/lens.ex
@@ -27,16 +27,16 @@ defmodule Lens do
 
   deflens key(key) do
     fn data, fun ->
-      {res, updated} = fun.(access_get(data, key))
-      {[res], access_put(data, key, updated)}
+      {res, updated} = fun.(data_get_key(data, key))
+      {[res], data_set_key(data, key, updated)}
     end
   end
 
   deflens keys(keys) do
     fn data, fun ->
       {res, changed} = Enum.reduce(keys, {[], data}, fn key, {results, data} ->
-        {res, changed} = fun.(access_get(data, key))
-        {[res | results], access_put(data, key, changed)}
+        {res, changed} = fun.(data_get_key(data, key))
+        {[res | results], data_set_key(data, key, changed)}
       end)
 
       {Enum.reverse(res), changed}
@@ -122,11 +122,11 @@ defmodule Lens do
     {Enum.concat(res), changed}
   end
 
-  defp access_get(data, key) when is_map(data), do: Map.get(data, key)
-  defp access_get(data, key), do: Access.get(data, key)
+  defp data_get_key(data, key) when is_map(data), do: Map.get(data, key)
+  defp data_get_key(data, key), do: Access.get(data, key)
 
-  defp access_put(data, key, value) when is_map(data), do: Map.put(data, key, value)
-  defp access_put(data, key, value) do
+  defp data_set_key(data, key, value) when is_map(data), do: Map.put(data, key, value)
+  defp data_set_key(data, key, value) do
     {_, updated} = Access.get_and_update(data, key, fn _ -> {nil, value} end)
     updated
   end

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -10,6 +10,8 @@ defmodule LensTest do
   describe "key" do
     test "to_list", do: assert Lens.to_list(%{a: :b}, Lens.key(:a)) == [:b]
 
+    test "to_list on keyword", do: assert Lens.to_list([a: :b], Lens.key(:a)) == [:b]
+
     test "each" do
       this = self
       Lens.each(%{a: :b}, Lens.key(:a), fn x -> send(this, x) end)
@@ -17,6 +19,7 @@ defmodule LensTest do
     end
 
     test "map", do: assert Lens.map(%{a: :b}, Lens.key(:a), fn :b -> :c end) == %{a: :c}
+    test "map on keyword", do: assert Lens.map([a: :b], Lens.key(:a), fn :b -> :c end) == [a: :c]
 
     test "get_and_map" do
       assert Lens.get_and_map(%{a: :b}, Lens.key(:a), fn :b -> {:c, :d} end) == {[:c], %{a: :d}}


### PR DESCRIPTION
With this change you can use `Lens.key` and `Lens.keys`
on Keyword values or any other type that implements the
Elixir `Access` protocol.