### PR TITLE
Improve installation section on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,10 @@ iex> Lens.get_and_map(data, lens, fn size -> {size, round(size)} end)
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+[Available in Hex](https://hex.pm/packages/lens), the package can be installed as:
 
   1. Add lens to your list of dependencies in `mix.exs`:
 
         def deps do
           [{:lens, "~> 0.0.1"}]
         end
-
-  2. Ensure lens is started before your application:
-
-        def application do
-          [applications: [:lens]]
-        end
-


### PR DESCRIPTION
Link to package page on hex.pm.
Remove instructions on starting lens as application, as it's just
an utility library.