### PR TITLE
Document Lens functions.

### DIFF
--- a/lib/lens.ex
+++ b/lib/lens.ex
@@ -3,7 +3,7 @@ defmodule Lens do
 
   @opaque t :: (:get, any, function -> list(any)) | (:get_and_update, any, function -> {list(any), any})
 
-  @doc """
+  @doc ~S"""
   Returns a lens that does not focus on any part of the data.
 
       iex> Lens.empty |> Lens.get(:anything)
@@ -14,7 +14,7 @@ defmodule Lens do
     fn data, _fun -> {[], data} end
   end
 
-  @doc """
+  @doc ~S"""
   Returns a lens that focuses on the whole data.
 
       iex> Lens.to_list(Lens.root, :data)
@@ -111,7 +111,7 @@ defmodule Lens do
   @spec all :: t
   deflens all, do: wrap filter(fn _ -> true end)
 
-  @doc """
+  @doc ~S"""
   Compose a pair of lens by applying the second to the result of the first
 
       iex> Lens.seq(Lens.key(:a), Lens.key(:b)) |> Lens.get(%{a: %{b: 3}})
@@ -247,13 +247,15 @@ defmodule Lens do
   def map(lens, data, fun), do: update_in(data, [lens], fun)
 
   @doc ~S"""
-  Get a tuple of original values and the updated data by applying fun on lens.
+  Get and update values inside data on a single pass as specified by the mapping function.
 
-  The mapping function takes a value and must return a tuple with old and update values.
+  The mapping function takes a each value form the lens and must return a tuple `{value_to_return, value_to_update_on_data}`
 
-      iex> data = [1, 2, 3]
-      iex> Lens.filter(&Integer.is_odd/1) |> Lens.get_and_map(data, fn v -> {v, v + 10} end)
-      {[1, 3], [11, 2, 13]}
+      iex> data = %{a: 1, b: 2, c: 3}
+      iex> Lens.keys([:a, :b, :c])
+      ...> |> Lens.satisfy(&Integer.is_odd/1)
+      ...> |> Lens.get_and_map(data, fn v -> {v + 1, v + 10} end)
+      {[2, 4], %{a: 11, b: 2, c: 13}}
   """
   @spec get_and_map(t, any, (any -> {any, any})) :: {list(any), any}
   def get_and_map(lens, data, fun), do: get_and_update_in(data, [lens], fun)

--- a/lib/lens.ex
+++ b/lib/lens.ex
@@ -1,10 +1,22 @@
 defmodule Lens do
   use Lens.Macros
 
+  @doc ~S"""
+  A lens that always reads as an empty list
+
+      iex> Lens.empty |> Lens.get(:anything)
+      []
+  """
   deflens empty do
     fn data, _fun -> {[], data} end
   end
 
+  @doc ~S"""
+  Create a lens that returns data as is
+
+      iex> Lens.root |> Lens.get(:anything)
+      :anything
+  """
   deflens root do
     fn data, fun ->
       {res, updated} = fun.(data)
@@ -12,12 +24,28 @@ defmodule Lens do
     end
   end
 
+  @doc ~S"""
+  Select lens based on a matcher function
+
+      iex> selector = fn
+      ...>  {:a, _} -> Lens.at(1)
+      ...>  {:b, _, _} -> Lens.at(2)
+      ...> end
+      iex> Lens.match(selector) |> Lens.get({:b, 2, 3})
+      3
+  """
   deflens match(matcher_fun) do
     fn data, fun ->
-      get_and_map(data, matcher_fun.(data), fun)
+      get_and_map(matcher_fun.(data), data, fun)
     end
   end
 
+  @doc ~S"""
+  Access a value at position
+
+      iex> Lens.at(2) |> Lens.get({:a, :b, :c})
+      :c
+  """
   deflens at(index) do
     fn data, fun ->
       {res, updated} = fun.(elem(data, index))
@@ -25,6 +53,12 @@ defmodule Lens do
     end
   end
 
+  @doc ~S"""
+  Access a value at key
+
+      iex> Lens.key(:foo) |> Lens.get(%{foo: 1})
+      1
+  """
   deflens key(key) do
     fn data, fun ->
       {res, updated} = fun.(Map.get(data, key))
@@ -32,6 +66,12 @@ defmodule Lens do
     end
   end
 
+  @doc ~S"""
+  Access values at given keys
+
+      iex> Lens.keys([:a, :c]) |> Lens.get(%{a: 1, b: 2, c: 3})
+      [1, 3]
+  """
   deflens keys(keys) do
     fn data, fun ->
       {res, changed} = Enum.reduce(keys, {[], data}, fn key, {results, data} ->
@@ -43,29 +83,78 @@ defmodule Lens do
     end
   end
 
+  @doc ~S"""
+  Access all items on an enumerable
+
+      iex> Lens.all |> Lens.get([1, 2, 3])
+      [1, 2, 3]
+  """
   deflens all, do: filter(fn _ -> true end)
 
+  @doc """
+  Compose a pair of lens by applying the second to the result of the first
+
+      iex> Lens.seq(Lens.key(:a), Lens.key(:b)) |> Lens.get(%{a: %{b: 3}})
+      3
+
+  Piping lenses has the exact same effect:
+
+      iex> Lens.key(:a) |> Lens.key(:b) |> Lens.get(%{a: %{b: 3}})
+      3
+  """
   deflens seq(lens1, lens2) do
     fn data, fun ->
-      {res, changed} = get_and_map(data, lens1, fn item ->
-        get_and_map(item, lens2, fun)
+      {res, changed} = get_and_map(lens1, data, fn item ->
+        get_and_map(lens2, item, fun)
       end)
       {Enum.concat(res), changed}
     end
   end
 
+  @doc ~S"""
+  Combine the composition of both lens with the first one.
+
+      iex> Lens.seq_both(Lens.key(:a), Lens.key(:b)) |> Lens.get(%{a: %{b: :c}})
+      [:c, %{b: :c}]
+  """
   deflens seq_both(lens1, lens2), do: Lens.both(Lens.seq(lens1, lens2), lens1)
 
+  @doc ~S"""
+  Make a lens recursive
+
+      iex> data = %{
+      ...>    items: [
+      ...>      %{v: 1, items: []},
+      ...>      %{v: 2, items: [
+      ...>        %{v: 3, items: []}
+      ...>      ]}
+      ...> ]}
+      iex> lens = Lens.recur(Lens.key(:items) |> Lens.all) |> Lens.key(:v)
+      iex> Lens.get(lens, data)
+      [1, 2, 3]
+  """
   deflens recur(lens), do: &do_recur(lens, &1, &2)
 
+  @doc ~S"""
+  Combine two lenses accessing both of them as one
+
+      iex> Lens.both(Lens.key(:a), Lens.key(:b) |> Lens.all) |> Lens.get(%{a: 1, b: [2, 3]})
+      [1, 2, 3]
+  """
   deflens both(lens1, lens2) do
     fn data, fun ->
-      {res1, changed1} = get_and_map(data, lens1, fun)
-      {res2, changed2} = get_and_map(changed1, lens2, fun)
+      {res1, changed1} = get_and_map(lens1, data, fun)
+      {res2, changed2} = get_and_map(lens2, changed1, fun)
       {res1 ++ res2, changed2}
     end
   end
 
+  @doc ~S"""
+  Lens to access values from an enumeration for which the given predicate is true
+
+      iex> Lens.filter(&Integer.is_odd/1) |> Lens.get([1, 2, 3, 4])
+      [1, 3]
+  """
   deflens filter(filter_fun) do
     fn data, fun ->
       {res, updated} = Enum.reduce(data, {[], []}, fn item, {res, updated} ->
@@ -80,9 +169,15 @@ defmodule Lens do
     end
   end
 
+  @doc ~S"""
+  Access values from a previous lens that satisfy the given predicate
+
+      iex> Lens.both(Lens.key(:a), Lens.key(:b)) |> Lens.satisfy(&Integer.is_odd/1) |> Lens.get(%{a: 1, b: 2})
+      1
+  """
   deflens satisfy(lens, filter_fun) do
     fn data, fun ->
-      {res, changed} = get_and_map(data, lens, fn item ->
+      {res, changed} = get_and_map(lens, data, fn item ->
         if filter_fun.(item) do
           {res, changed} = fun.(item)
           {[res], changed}
@@ -94,26 +189,66 @@ defmodule Lens do
     end
   end
 
-  def to_list(data, lens) do
-    {list, _} = get_and_map(data, lens, &{&1, &1})
+  @doc ~S"""
+  Obtain a list of values from a lens
+
+      iex> Lens.keys([:a, :c]) |> Lens.to_list(%{a: 1, b: 2, c: 3})
+      [1, 3]
+  """
+  def to_list(lens, data) do
+    {list, _} = get_and_map(lens, data, &{&1, &1})
     list
   end
 
-  def each(data, lens, fun) do
-    {_, _} = get_and_map(data, lens, &{nil, fun.(&1)})
+  @doc ~S"""
+  Perform a side effect on each value from a lens
+
+      iex> data = %{a: 1, b: 2, c: 3}
+      iex> fun = fn -> Lens.keys([:a, :c]) |> Lens.each(data, &IO.inspect/1) end
+      iex> import ExUnit.CaptureIO
+      iex> capture_io(fun)
+      "1\n3\n"
+  """
+  def each(lens, data, fun) do
+    {_, _} = get_and_map(lens, data, &{nil, fun.(&1)})
+    :ok
   end
 
-  def map(data, lens, fun) do
-    {_, changed} = get_and_map(data, lens, &{nil, fun.(&1)})
+  @doc ~S"""
+  Obtain the updated version of data by applying fun on lens.
+
+      iex> data = [1, 2, 3, 4]
+      iex> Lens.filter(&Integer.is_odd/1) |> Lens.map(data, fn v -> v + 10 end)
+      [11, 2, 13, 4]
+  """
+  def map(lens, data, fun) do
+    {_, changed} = get_and_map(lens, data, &{nil, fun.(&1)})
     changed
   end
 
-  def get_and_map(data, lens, fun) do
+  @doc ~S"""
+  Get a tuple of original values and the updated data by applying fun on lens.
+
+  The mapping function takes a value and must return a tuple with old and update values.
+
+      iex> data = [1, 2, 3]
+      iex> Lens.filter(&Integer.is_odd/1) |> Lens.get_and_map(data, fn v -> {v, v + 10} end)
+      {[1, 3], [11, 2, 13]}
+  """
+  def get_and_map(lens, data, fun) do
     lens.(data, fun)
   end
 
+  @doc ~S"""
+  Executes `to_list` and returns the first item if the list has only one item otherwise the full list.
+  """
+  def get(lens, data) do
+    to_list(lens, data) |> fn [x] -> x; x -> x end.()
+  end
+
+
   defp do_recur(lens, data, fun) do
-    {res, changed} = get_and_map(data, lens, fn item ->
+    {res, changed} = get_and_map(lens, data, fn item ->
       {results, changed1} = do_recur(lens, item, fun)
       {res_parent, changed2} = fun.(changed1)
       {[res_parent | results], changed2}

--- a/lib/lens/macros.ex
+++ b/lib/lens/macros.ex
@@ -13,7 +13,16 @@ defmodule Lens.Macros do
     end
 
     quote do
-      def unquote(header), do: unquote(body)
+      def unquote(header) do
+        lens = unquote(body)
+        fn
+          :get, data, next ->
+            {list, _} = lens.(data, &{&1, &1})
+            next.(list)
+          :get_and_update, data, mapper ->
+            lens.(data, mapper)
+        end
+      end
 
       @doc false
       def unquote(name)(previous, unquote_splicing(args)) do

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -8,75 +8,75 @@ defmodule LensTest do
   end
 
   describe "key" do
-    test "to_list", do: assert Lens.to_list(%{a: :b}, Lens.key(:a)) == [:b]
+    test "to_list", do: assert Lens.to_list(Lens.key(:a), %{a: :b}) == [:b]
 
     test "each" do
       this = self
-      Lens.each(%{a: :b}, Lens.key(:a), fn x -> send(this, x) end)
+      Lens.each(Lens.key(:a), %{a: :b}, fn x -> send(this, x) end)
       assert_receive :b
     end
 
-    test "map", do: assert Lens.map(%{a: :b}, Lens.key(:a), fn :b -> :c end) == %{a: :c}
+    test "map", do: assert Lens.map(Lens.key(:a), %{a: :b}, fn :b -> :c end) == %{a: :c}
 
     test "get_and_map" do
-      assert Lens.get_and_map(%{a: :b}, Lens.key(:a), fn :b -> {:c, :d} end) == {[:c], %{a: :d}}
-      assert Lens.get_and_map(%TestStruct{a: 1}, Lens.key(:a), fn x -> {x, x + 1} end) == {[1], %TestStruct{a: 2}}
+      assert Lens.get_and_map(Lens.key(:a), %{a: :b}, fn :b -> {:c, :d} end) == {[:c], %{a: :d}}
+      assert Lens.get_and_map(Lens.key(:a), %TestStruct{a: 1}, fn x -> {x, x + 1} end) == {[1], %TestStruct{a: 2}}
     end
   end
 
   describe "keys" do
     test "get_and_map" do
-      assert Lens.get_and_map(%{a: :b, c: :d, e: :f}, Lens.keys([:a, :e]), fn x-> {x, :x} end) ==
+      assert Lens.get_and_map(Lens.keys([:a, :e]), %{a: :b, c: :d, e: :f}, fn x-> {x, :x} end) ==
         {[:b, :f], %{a: :x, c: :d, e: :x}}
-      assert Lens.get_and_map(%TestStruct{a: 1, b: 2, c: 3}, Lens.keys([:a, :c]), fn x -> {x, x + 1} end) ==
+      assert Lens.get_and_map(Lens.keys([:a, :c]), %TestStruct{a: 1, b: 2, c: 3}, fn x -> {x, x + 1} end) ==
         {[1, 3], %TestStruct{a: 2, b: 2, c: 4}}
     end
   end
 
   describe "all" do
-    test "to_list", do: assert Lens.to_list([:a, :b, :c], Lens.all) == [:a, :b, :c]
+    test "to_list", do: assert Lens.to_list(Lens.all, [:a, :b, :c]) == [:a, :b, :c]
 
     test "each" do
       this = self
-      Lens.each([:a, :b, :c], Lens.all, fn x -> send(this, x) end)
+      Lens.each(Lens.all, [:a, :b, :c], fn x -> send(this, x) end)
       assert_receive :a
       assert_receive :b
       assert_receive :c
     end
 
-    test "map", do: assert Lens.map([:a, :b, :c], Lens.all, fn :a -> 1; :b -> 2; :c -> 3 end) == [1, 2, 3]
+    test "map", do: assert Lens.map(Lens.all, [:a, :b, :c], fn :a -> 1; :b -> 2; :c -> 3 end) == [1, 2, 3]
 
     test "get_and_map" do
-      assert Lens.get_and_map([:a, :b, :c], Lens.all, fn x -> {x, :d} end) == {[:a, :b, :c], [:d, :d, :d]}
+      assert Lens.get_and_map(Lens.all, [:a, :b, :c], fn x -> {x, :d} end) == {[:a, :b, :c], [:d, :d, :d]}
     end
   end
 
   describe "filter" do
     test "get_and_map" do
-      assert Lens.get_and_map([1, 2, 3, 4], Lens.filter(&Integer.is_odd/1), fn n -> {n, n + 1} end) ==
+      assert Lens.get_and_map(Lens.filter(&Integer.is_odd/1), [1, 2, 3, 4], fn n -> {n, n + 1} end) ==
         {[1, 3], [2, 2, 4, 4]}
     end
   end
 
   describe "seq" do
-    test "to_list", do: assert Lens.to_list(%{a: %{b: :c}}, Lens.seq(Lens.key(:a), Lens.key(:b))) == [:c]
+    test "to_list", do: assert Lens.to_list(Lens.seq(Lens.key(:a), Lens.key(:b)), %{a: %{b: :c}}) == [:c]
 
     test "each" do
       this = self
-      Lens.each(%{a: %{b: :c}}, Lens.seq(Lens.key(:a), Lens.key(:b)), fn x -> send(this, x) end)
+      Lens.each(Lens.seq(Lens.key(:a), Lens.key(:b)), %{a: %{b: :c}}, fn x -> send(this, x) end)
       assert_receive :c
     end
 
-    test "map", do: assert Lens.map(%{a: %{b: :c}}, Lens.seq(Lens.key(:a), Lens.key(:b)), fn :c -> :d end) == %{a: %{b: :d}}
+    test "map", do: assert Lens.map(Lens.seq(Lens.key(:a), Lens.key(:b)), %{a: %{b: :c}}, fn :c -> :d end) == %{a: %{b: :d}}
 
     test "get_and_map" do
-      assert Lens.get_and_map(%{a: %{b: :c}}, Lens.seq(Lens.key(:a), Lens.key(:b)), fn :c -> {:d, :e} end) == {[:d], %{a: %{b: :e}}}
+      assert Lens.get_and_map(Lens.seq(Lens.key(:a), Lens.key(:b)), %{a: %{b: :c}}, fn :c -> {:d, :e} end) == {[:d], %{a: %{b: :e}}}
     end
   end
 
   describe "seq_both" do
     test "get_and_map" do
-      assert Lens.get_and_map(%{a: %{b: :c}}, Lens.seq_both(Lens.key(:a), Lens.key(:b)), fn
+      assert Lens.get_and_map(Lens.seq_both(Lens.key(:a), Lens.key(:b)), %{a: %{b: :c}}, fn
         :c -> {2, :d}
         %{b: :d} -> {1, %{b: :e}}
       end) == {[2, 1], %{a: %{b: :e}}}
@@ -85,7 +85,7 @@ defmodule LensTest do
 
   describe "both" do
     test "get_and_map" do
-      assert Lens.get_and_map(%{a: 1, b: [2, 3]}, Lens.both(Lens.key(:a), Lens.seq(Lens.key(:b), Lens.all)), fn x -> {x, x + 1} end) ==
+      assert Lens.get_and_map(Lens.both(Lens.key(:a), Lens.seq(Lens.key(:b), Lens.all)), %{a: 1, b: [2, 3]}, fn x -> {x, x + 1} end) ==
         {[1, 2, 3], %{a: 2, b: [3, 4]}}
     end
   end
@@ -94,8 +94,8 @@ defmodule LensTest do
     test "get_and_map" do
       lens =
         Lens.both(Lens.keys([:a, :b]), Lens.seq(Lens.key(:c), Lens.all))
-        |> Lens.satisfy(fn n -> Integer.is_odd(n) end)
-      assert Lens.get_and_map(%{a: 1, b: 2, c: [3, 4]}, lens, fn x -> {x, x + 1} end) ==
+        |> Lens.satisfy(&Integer.is_odd/1)
+      assert Lens.get_and_map(lens, %{a: 1, b: 2, c: [3, 4]}, fn x -> {x, x + 1} end) ==
         {[1, 3], %{a: 2, b: 2, c: [4, 4]}}
     end
   end
@@ -114,7 +114,7 @@ defmodule LensTest do
 
       lens = Lens.recur(Lens.seq(Lens.key(:items), Lens.all)) |> Lens.seq(Lens.key(:data))
 
-      assert Lens.get_and_map(data, lens, fn x -> {x, x + 1} end) == {[2, 3, 4], %{
+      assert Lens.get_and_map(lens, data, fn x -> {x, x + 1} end) == {[2, 3, 4], %{
         data: 1,
         items: [
           %{data: 3, items: []},
@@ -126,24 +126,23 @@ defmodule LensTest do
   end
 
   describe "at" do
-    assert Lens.get_and_map({1, 2, 3}, Lens.at(1), fn x -> {x, x + 1} end) == {[2], {1, 3, 3}}
+    assert Lens.get_and_map(Lens.at(1), {1, 2, 3}, fn x -> {x, x + 1} end) == {[2], {1, 3, 3}}
   end
 
   describe "match" do
     test "get_and_map" do
-      require Lens
       lens = Lens.seq(Lens.all, Lens.match(fn
         {:a, _} -> Lens.at(1)
         {:b, _, _} -> Lens.at(2)
       end))
 
-      assert Lens.get_and_map([{:a, 1}, {:b, 2, 3}], lens, fn x -> {x, x + 1} end) == {[1, 3], [{:a, 2}, {:b, 2, 4}]}
+      assert Lens.get_and_map(lens, [{:a, 1}, {:b, 2, 3}], fn x -> {x, x + 1} end) == {[1, 3], [{:a, 2}, {:b, 2, 4}]}
     end
   end
 
   describe "empty" do
     test "get_and_map" do
-      assert Lens.get_and_map({:arbitrary, :data}, Lens.empty, fn -> raise "never_called" end) == {[], {:arbitrary, :data}}
+      assert Lens.get_and_map(Lens.empty, {:arbitrary, :data}, fn -> raise "never_called" end) == {[], {:arbitrary, :data}}
     end
   end
 
@@ -154,13 +153,13 @@ defmodule LensTest do
       data = %{a: [%{b: 1}, %{b: 2}]}
       fun = fn x -> {x, x + 1} end
 
-      assert Lens.get_and_map(data, lens1, fun) == Lens.get_and_map(data, lens2, fun)
+      assert Lens.get_and_map(lens1, data, fun) == Lens.get_and_map(lens2, data, fun)
     end
   end
 
   describe "root" do
     test "get_and_map" do
-      assert Lens.get_and_map(1, Lens.root, fn x -> {x, x + 1} end) == {[1], 2}
+      assert Lens.get_and_map(Lens.root, 1, fn x -> {x, x + 1} end) == {[1], 2}
     end
   end
 end

--- a/test/lens_test.exs
+++ b/test/lens_test.exs
@@ -168,4 +168,20 @@ defmodule LensTest do
       assert Lens.get_and_map(Lens.root, 1, fn x -> {x, x + 1} end) == {[1], 2}
     end
   end
+
+  describe "lens as access key" do
+    test "Kernel.get_in" do
+      value = %{a: 1, b: 2, c: 3}
+      |> get_in([Lens.keys([:a, :c])])
+      |> Enum.map(&to_string/1)
+
+      assert value == ["1", "3"]
+    end
+
+    test "Kernel.update_in" do
+      value = %{a: 1, b: 2, c: 3}
+      |> update_in([Lens.keys([:a, :c])], fn x -> x * 4 end)
+      assert value == %{a: 4, b: 2, c: 12}
+    end
+  end
 end


### PR DESCRIPTION
Added documentation with a simple example on each so that users
can get a quick glimpse at how each lens works.

As we are still on `v0` I made some changes to make the functions
be more Elixir way, for example, made `to_list`, `map`, `each`, and
`get_and_update` take the lens as first parameter, to ease piping
and to be more consistent with mapping collections in elixir.

```elixir
Lens.filter(&Integer.is_odd/1) |> Lens.map([1, 2], fn v -> v + 10 end)
```

Also added `Lens.get` which is just `Lens.list` but unwraps the
value if the list length is one, otherwise returns the whole list.